### PR TITLE
Add $TRAVIS_PULL_REQUEST check logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_install:
 script:
 - flake8 .
 after_success:
-- test $TRAVIS_BRANCH = "master" && zappa update production
+- test $TRAVIS_BRANCH = "master" && test $TRAVIS_PULL_REQUEST = "false" && zappa update production


### PR DESCRIPTION
For builds triggered by a pull request, `$TRAVIS_BRANCH` is the name of the branch targeted by the pull request. I added additional check logic to restrict `zappa update` process when it is PR.