### PR TITLE
Add tutorial and sprint info on timetable query

### DIFF
--- a/skills/timetable.py
+++ b/skills/timetable.py
@@ -21,5 +21,8 @@ from skills import add_skill
 @add_skill(r'시간표', help_text='파이콘 2019 프로그램 시간표를 제공합니다.')
 def get_timetable(message):
     return TextSendMessage(
-        text='시간표는 https://www.pycon.kr/timetable/talks 에서 확인해주세요'
+        text='시간표는 https://www.pycon.kr/timetable/talks (컨퍼런스)'
+             ', https://www.pycon.kr/timetable/tutorial (튜토리얼)'
+             ', https://www.pycon.kr/timetable/sprint (스프린트)'
+             '에서 확인해주세요'
     )


### PR DESCRIPTION
This patch proposes to add texts from a timetable query
to also provide tutorial and sprint information.

- [v] You must sign the ICLA to accept your pull request. 
      (see the [CONTRIBUTING] about this)

* Your email: ianyrchoi@gmail.com
* Brief description about this pull request: This patch add tutorial and sprint texts on timetable query


[CONTRIBUTING]: https://github.com/line/line-bot-pyconkr2019/blob/master/CONTRIBUTING.md